### PR TITLE
Fix cronflow forEach registration and tests

### DIFF
--- a/sdk/src/workflow/instance.ts
+++ b/sdk/src/workflow/instance.ts
@@ -1444,6 +1444,15 @@ export class WorkflowInstance {
     this._workflow.steps.push(forEachStep);
     this._currentStep = forEachStep;
 
+    if (this._cronflowInstance && this._cronflowInstance.registerStepHandler) {
+      this._cronflowInstance.registerStepHandler(
+        this._workflow.id,
+        forEachStep.name,
+        forEachStep.handler,
+        'step'
+      );
+    }
+
     return this;
   }
 


### PR DESCRIPTION
## 📋 Pull Request

### 📝 Description

**What does this PR do?**

- Registers `forEach_*` steps with the Cronflow engine so parallel iterations are discoverable at runtime.  
- Updates the advanced control-flow example test to use the new step shape and to assert handler registration.  
- Executes the `foreach-test` workflow during the example run to demonstrate the handlers executing (logs now appear).

**Why is this change needed?**

Manual executions (for example via `cronflow.trigger`) failed with “Step handler not found: forEach_*” because `forEach` steps weren’t registered. This fix makes parallel loops behave like regular steps, restoring manual-run support and unblocking downstream tooling.

### 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)  
- [x] 🧪 Test additions or updates

### 🔗 Related Issues

🫡 
